### PR TITLE
Added Existing DB/Table/Field Examples

### DIFF
--- a/associations.md
+++ b/associations.md
@@ -156,6 +156,73 @@ Pet.find()
 
 });
 ```
+##### One-to-One with Existing Tables
+
+These one-to-one relationships will also work if you're using a legacy database. You'll have to specify a `tableName` attribute, along with appropriate `columnName`s for each field attribute.
+
+In this example, PetBiz prefixes all of their tables and fields with `pb_`. So the Pet model becomes:
+```javascript
+var Pet = Waterline.Collection.extend({
+
+  identity: 'pet',
+  connection: 'local-postgresql',
+  tableName: 'pb_pets'
+
+  attributes: {
+    id: {
+      type: 'integer',
+      primaryKey: true
+    },
+    breed: {
+      type: 'string',
+      columnName: 'pb_pet_breed'
+    },
+    animal: {
+      type: 'string',
+      columnName: 'pb_pet_species'
+    },
+    name: {
+      type: 'string',
+      columnName: 'pb_pet_name'
+    },
+    
+    // And here we make the association:
+    owner: {
+      model: 'user'
+    }
+  }
+});
+```
+Meanwhile, the `User` would look something like this:
+```javascript
+var User = Waterline.Collection.extend({
+
+  identity: 'user',
+  connection: 'local-postgresql',
+  tableName: 'pb_user'
+
+  attributes: {
+    id: {
+      type: 'integer',
+      primaryKey: true
+    },
+    firstName: {
+      type: 'string',
+      columnName: 'pb_owner_first'
+    },
+    lastName: {
+      type: 'string',
+      columnName: 'pb_owner_last'
+    },
+
+    // Add a reference to Pet
+    pet: {
+      model: 'pet'
+    }
+  }
+});
+```
+With just these minor changes to the model, the queries described earlier should work the same.
 
 ### One-to-Many Associations
 

--- a/models.md
+++ b/models.md
@@ -753,6 +753,39 @@ var Foo = Waterline.Collection.extend({
 });
 ```
 
+#### Using an Existing Database
+  
+There might be times when you want to use an existing database in your models.
+
+In this example, the WB Company has prefixed all of their fields with `wb_`. You'll notice that you can use the `tableName` attribute, but also `columnName` in the `attributes` object. Additionally, we will set `migrate: 'safe'` so that Waterline doesn't attempt to add/remove fields or otherwise automatically restructure the existing database.
+
+```javascript
+var Widget = Waterline.Collection.extend({
+  identity: 'wbwidget',
+  connection: 'wb-widget-database',
+  tableName: 'wb_widgets',
+  attributes: {
+    id: {
+      type: 'integer',
+      columnName: 'wb_id',
+      primaryKey: true
+    },
+    name: {
+      type: 'string',
+      columnName: 'wb_name'
+    },
+    description: {
+      type: 'text',
+      columnName: 'wb_description'
+    }
+    autoPK: false,
+    autoCreatedAt: false,
+    autoUpdatedAt: false,
+  }
+});
+```
+`autoPK`, `autoCreatedAt`, and `autoUpdatedAt` are set to false in this example, because we want the model to be read-only from existing fields.
+
 ### Class Methods
 
 "Class" methods are functions available at the top level of a model. They can be called anytime after


### PR DESCRIPTION
Hi.

I've gone ahead and added examples for working with existing database tables and fields to both `models.md` and `associations.md`.

In the latter, I was only able to add to the One-to-One relationship, because I'm still not quite sure how to properly structure models in a One-to-Many or Many-to-Many when the table names and fields are already defined (and especially when their structure cannot be altered).

I see you've already put a section at the bottom for documenting the Many-to-Many relationships that make use of existing `join` tables, which I assume involves making a third model between the two (that would then not have a controller). I'm willing to help with that part of the documentation once I'm clear on all the options. Diving into the code blind, I haven't been able to figure it out on my own.

What are all of the attribute options that are relevant to relationships? So far, I've discovered `via`, `on`, `references`, and `through`, but I'm not clear which of these are deprecated (if any) or what they do. If you point me to the right source file or give me a quick summary I can whip up some examples and add it to the docs.

Let me know what you think man.