### PR TITLE
Update outdated links in models.md

### DIFF
--- a/models.md
+++ b/models.md
@@ -236,8 +236,8 @@ attributes: {
 ### Validations
 
 Validations are handled by [Anchor](https://github.com/balderdashy/anchor) which is based off of
-[Node Validate](https://github.com/chriso/node-validator) and supports most of the properties in
-node-validate. For a full list of validations see: [Anchor Validations](https://github.com/balderdashy/anchor/blob/master/lib/rules.js).
+[Node Validate](https://github.com/chriso/validator.js) and supports most of the properties in
+node-validate. For a full list of validations see: [Anchor Validations](https://github.com/balderdashy/anchor/blob/master/lib/match/rules.js).
 
 Validations are defined directly in your Collection attributes. In addition you may set the attribute
 type to any supported Anchor type and Waterline will build a validation and set the schema type as


### PR DESCRIPTION
Node Validate points to the proper repository
List of validations was moved so the link is now pointing to the updated location
