### PR TITLE
defaultsTo can be a method

### DIFF
--- a/models.md
+++ b/models.md
@@ -116,7 +116,7 @@ on the data.
 
 ###### defaultsTo
 
-Will set a default value on an attribute if one is not supplied when the record is created. The supllied value can also be a 
+Will set a default value on an attribute if one is not supplied when the record is created. The supplied value can also be a 
 function that waterline will run while creating the record.
 
 ```javascript

--- a/models.md
+++ b/models.md
@@ -116,13 +116,20 @@ on the data.
 
 ###### defaultsTo
 
-Will set a default value on an attribute if one is not supplied when the record is created.
+Will set a default value on an attribute if one is not supplied when the record is created. The supllied value can also be a 
+function that waterline will run while creating the record.
 
 ```javascript
 attributes: {
   phoneNumber: {
     type: 'string',
     defaultsTo: '111-222-3333'
+  },
+  id: {
+    type: 'text',
+    primaryKey: true,
+    unique: true,
+    defaultsTo: function() { return uuid.v4(); }
   }
 }
 ```


### PR DESCRIPTION
As per https://github.com/balderdashy/waterline/blob/e9b618fe0910dd4ffc4a9e4af43a494592c4e9ff/lib/waterline/query/dql/create.js#L93, defaultsTo can be a method. Added it to the docs.