### PR TITLE
Removed the promisey pyramid of doom

### DIFF
--- a/introduction/getting-started.md
+++ b/introduction/getting-started.md
@@ -111,24 +111,26 @@ waterline.initialize(config, function (err, ontology) {
 	var User = ontology.collections.user;
 	var Pet = ontology.collections.pet;
 
-	// First we create a user.
-	User.create({
-			firstName: 'Neil',
-			lastName: 'Armstrong'
-		}).then(function (user) {
-			return Pet.create({
-				breed: 'beagle',
-				type: 'dog',
-				name: 'Astro',
-				owner: user.id
-			});
-			
-		}).then(function () {
-			return User.find()
-				.populate('pets');
-				
-		}).then(console.log.bind(console))
-		.catch(console.error.bind(console));
+    User.create({ // First we create a user.
+            firstName: 'Neil',
+            lastName: 'Armstrong'
+        }).then(function (user) { // Then we create the pet
+            return Pet.create({
+                breed: 'beagle',
+                type: 'dog',
+                name: 'Astro',
+                owner: user.id
+            });
+
+        }).then(function (pet) { // Then we grab all users and their pets
+            return User.find().populate('pets');
+
+        }).then(function(users){ // Results of the previous then clause are passed to the next
+             console.dir(users);
+
+        }).catch(function(err){ // If any errors occur execution jumps to the catch block.
+			console.error(err);
+		});
 });
 ```
 

--- a/introduction/getting-started.md
+++ b/introduction/getting-started.md
@@ -115,26 +115,20 @@ waterline.initialize(config, function (err, ontology) {
 	User.create({
 			firstName: 'Neil',
 			lastName: 'Armstrong'
-		})
-		.then(function (user) {
-			Pet.create({
+		}).then(function (user) {
+			return Pet.create({
 				breed: 'beagle',
 				type: 'dog',
 				name: 'Astro',
 				owner: user.id
-			})
-				.then(function (pet) {
-					user.pets = [pet];
-
-					return user.save();
-				})
-				.then(function () {
-					return User.find()
-						.populate('pets');
-				})
-				.then(console.log)
-				.catch(console.error);
-		});
+			});
+			
+		}).then(function () {
+			return User.find()
+				.populate('pets');
+				
+		}).then(console.log.bind(console))
+		.catch(console.error.bind(console));
 });
 ```
 


### PR DESCRIPTION
There seems to be a few things wrong with this code snippet. 

1) The catch block should be on the outside promise. If `User.create` fails you will have no idea.
2) When passing `console.log` or `console.error` into `then` or `catch` you should bind this to console

3) Is it really necessary to save the relationship going backwards as well? Granted I'm not a waterline expert but I don't remember having to do this when working with sails.

I understand that you guys nested the promise because you needed to capture `user`. But if you don't need to save it back it would probably be best not having an example with a nested promise. Lots of people don't fully understand promises and seeing nested promises as examples will just lead to them creating promise callback hell. 